### PR TITLE
Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+hamaddr/target
+hamaddr/Cargo.lock

--- a/hamaddr/Cargo.toml
+++ b/hamaddr/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hamaddr"
+version = "0.1.0"
+edition = "2018"
+authors = ["kz2x", "n6drc"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/hamaddr/Cargo.toml
+++ b/hamaddr/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["kz2x", "n6drc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"

--- a/hamaddr/src/lib.rs
+++ b/hamaddr/src/lib.rs
@@ -1,0 +1,322 @@
+type Result<T> = std::result::Result<T, String>;
+
+/// Eui48 represents an EUI48 MAC address.
+pub struct Eui48([u8; 6]);
+
+impl Eui48 {
+    /// Creates a new Eui48 from the given six octets.
+    pub const fn new(addr: [u8; 6]) -> Eui48 {
+        Eui48(addr)
+    }
+
+    /// Returns a string representing the Eui48.
+    pub fn to_hex_string(&self) -> String {
+        let bs = &self.0;
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            bs[0], bs[1], bs[2], bs[3], bs[4], bs[5]
+        )
+    }
+
+    /// Returns a HamAddr from the Eui48.
+    pub fn to_ham_addr(&self) -> HamAddr {
+        let mut octets = self.0;
+        octets[0] &= 0b1111_1101;
+        octets.rotate_left(1);
+        let mut bytes = [0; 8];
+        bytes[..6].copy_from_slice(&octets);
+        let addr = u64::from_be_bytes(bytes);
+        HamAddr(addr)
+    }
+}
+
+/// Eui64 represents an EUI64 MAC address.
+pub struct Eui64([u8; 8]);
+
+impl Eui64 {
+    /// Creates a new Eui64 from the given 8 octets.
+    pub const fn new(addr: [u8; 8]) -> Eui64 {
+        Eui64(addr)
+    }
+
+    /// Returns a string representing the Eui64.
+    pub fn to_hex_string(&self) -> String {
+        let bs = &self.0;
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            bs[0], bs[1], bs[2], bs[3], bs[4], bs[5], bs[6], bs[7]
+        )
+    }
+
+    /// Returns a HamAddr from the Eui64.
+    pub fn to_ham_addr(&self) -> HamAddr {
+        let mut bytes = self.0;
+        bytes[0] &= 0b1111_1101;
+        if bytes[3] == 0xFF && bytes[4] == 0xFE {
+            bytes[3..].rotate_left(2);
+            bytes[6] = 0;
+            bytes[7] = 0;
+            bytes[..6].rotate_left(1);
+        } else {
+            bytes.rotate_left(1);
+        }
+        let addr = u64::from_be_bytes(bytes);
+        HamAddr(addr)
+    }
+}
+
+/// Conversion from an Eui48 to an Eui64 always succeeds.
+impl From<&Eui48> for Eui64 {
+    fn from(eui48: &Eui48) -> Self {
+        let mut bytes = [0; 8];
+        bytes[..3].copy_from_slice(&eui48.0[..3]);
+        bytes[3] = 0xFF;
+        bytes[4] = 0xFE; // See RFC 4291, App A.
+        bytes[5..].copy_from_slice(&eui48.0[3..]);
+        Eui64(bytes)
+    }
+}
+
+#[cfg(test)]
+mod eui_tests {
+    use super::*;
+
+    #[test]
+    fn test_from_eiu48_for_eui64() {
+        let eui48 = Eui48::new([1, 2, 3, 4, 5, 6]);
+        let eui64 = Eui64::from(&eui48);
+        assert_eq!(eui64.0, [1, 2, 3, 0xFF, 0xFE, 4, 5, 6]);
+    }
+
+    #[test]
+    fn test_to_hex_str_eui48() {
+        let eui = Eui48::new([1, 2, 3, 4, 5, 6]);
+        let s = eui.to_hex_string();
+        assert_eq!(s, "01:02:03:04:05:06");
+    }
+
+    #[test]
+    fn test_to_hex_str_eui64() {
+        let eui = Eui64::new([1, 2, 3, 4, 5, 6, 0x77, 0x88]);
+        let s = eui.to_hex_string();
+        assert_eq!(s, "01:02:03:04:05:06:77:88");
+    }
+}
+
+/// An ARNCE encoded address
+pub struct HamAddr(u64);
+
+impl HamAddr {
+    const CHARS: &'static str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-\\^";
+
+    /// Parses a call sign into a HamAddr.
+    pub fn parse_callsign(callsign: &str) -> Result<HamAddr> {
+        fn char_to_index(c: char) -> Result<u16> {
+            HamAddr::CHARS
+                .find(c)
+                .ok_or(format!("bad char '{}'", c))
+                .map(|k| k as u16 + 1)
+        }
+        fn chunk_to_u16(chunk: &[char]) -> u16 {
+            assert!(chunk.len() <= 3);
+
+            let (quad, _) = chunk
+                .into_iter()
+                .map(|c| char_to_index(*c).unwrap())
+                .fold((0, 40 * 40), |(sum, m), c| (sum + m * c, m / 40));
+            quad
+        }
+        for c in callsign.to_uppercase().chars() {
+            if !HamAddr::CHARS.contains(c) {
+                return Err(format!("Callsign contains bad character '{}'", c));
+            }
+        }
+        if callsign.len() > 12 {
+            return Err(format!("Callsign '{}' is too long", callsign));
+        }
+        let numeric = callsign
+            .to_uppercase()
+            .chars()
+            .collect::<Vec<_>>()
+            .chunks(3)
+            .map(|c| chunk_to_u16(c))
+            .chain([0, 0, 0, 0])
+            .take(4)
+            .fold(0, |addr, c| (addr << 16) | u64::from(c));
+        Ok(HamAddr(numeric))
+    }
+
+    /// Given a valid HamAddr, retrieves the corresponding callsign.
+    pub fn to_callsign(&self) -> String {
+        fn index_to_char(k: usize) -> Option<char> {
+            assert!(k < 40);
+            if k == 0 {
+                return None;
+            }
+            Some(HamAddr::CHARS.chars().nth(k - 1).unwrap())
+        }
+        fn chunk_to_chars(hi: u8, lo: u8) -> String {
+            let hex = u16::from(hi) << 8 | u16::from(lo);
+            let cs = [
+                index_to_char((usize::from(hex) / 1600) % 40),
+                index_to_char((usize::from(hex) / 40) % 40),
+                index_to_char((usize::from(hex) / 1) % 40),
+            ];
+            cs.iter().flatten().collect()
+        }
+        let bytes = self.0.to_be_bytes();
+        bytes
+            .chunks(2)
+            .map(|pair| chunk_to_chars(pair[0], pair[1]))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    /// Returns a hex string representing the HamAddr.
+    pub fn to_hex_string(&self) -> String {
+        let cs = [
+            (self.0 >> 48) as u16,
+            (self.0 >> 32) as u16,
+            (self.0 >> 16) as u16,
+            self.0 as u16,
+        ];
+        cs.iter()
+            .filter(|c| **c != 0)
+            .map(|c| format!("{:04X}", *c))
+            .collect::<Vec<_>>()
+            .join(":")
+    }
+
+    /// Returns a HAM64 encoded string corresponding to the HamAddr.
+    pub fn to_ham64_string(&self) -> String {
+        let cs = [
+            (self.0 >> 48) as u16,
+            (self.0 >> 32) as u16,
+            (self.0 >> 16) as u16,
+            self.0 as u16,
+        ];
+        cs.iter()
+            .map(|c| format!("{:04X}", *c))
+            .collect::<Vec<_>>()
+            .join("-")
+    }
+
+    /// Attempts to convert the HamAddr to an Eui64.
+    pub fn to_eui64(&self) -> Result<Eui64> {
+        if self.0 & 0b0111 != 0 {
+            return Err("HamAddr too big".to_string());
+        }
+        let is_small = self.0 & 0x0000_0000_0007_FFFF == 0;
+        let mut bytes = self.0.to_be_bytes();
+        let first_byte = std::mem::take(&mut bytes[if is_small { 5 } else { 7 }]);
+        bytes.rotate_right(1);
+        bytes[0] = (first_byte & 0b1111_1000) | 0b0010;
+        if is_small {
+            bytes[3..].rotate_right(2);
+            bytes[3] = 0xFF;
+            bytes[4] = 0xFE;
+        }
+        Ok(Eui64::new(bytes))
+    }
+
+    /// Attempts to convert the HamAddr to an Eui48.
+    pub fn to_eui48(&self) -> Result<Eui48> {
+        if self.0 & 0x0000_0000_0007_FFFF != 0 {
+            return Err("HamAddr too big".to_string());
+        }
+        let mut bytes = [0, 0, 0, 0, 0, 0];
+        bytes.copy_from_slice(&self.0.to_be_bytes()[..6]);
+        bytes.rotate_right(1);
+        bytes[0] = (bytes[0] & 0b1111_1000) | 0b0010;
+        Ok(Eui48::new(bytes))
+    }
+}
+
+#[cfg(test)]
+mod ham_addr_tests {
+    use super::*;
+
+    #[test]
+    fn test_ham_addr_parse_callsign() {
+        let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
+        assert_eq!(addr.to_callsign(), "KZ2X-1");
+    }
+
+    #[test]
+    fn test_ham_addr_to_hex_string() {
+        let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
+        assert_eq!(addr.to_hex_string(), "48ED:9C0C");
+
+        let addr = HamAddr::parse_callsign("N6DRC").unwrap();
+        assert_eq!(addr.to_hex_string(), "5CAC:70F8");
+        assert_eq!(addr.to_ham64_string(), "5CAC-70F8-0000-0000");
+
+        let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
+        assert_eq!(addr.to_hex_string(), "8B05:0E89:7118:A8C0");
+
+        // TODO(cross): This was one of the test vectors from the
+        // ARNCE specification, but the encoded ham64 string does
+        // not match the value below.  Check with N6DRC.
+        //
+        let addr = HamAddr::parse_callsign("KJ6QOH/P").unwrap();
+        // assert_eq!(addr.to_ham64_string(), "4671-6CA0-F000-0000");
+        assert_eq!(addr.to_ham64_string(), "4671-6CA0-E9C0-0000");
+    }
+
+    #[test]
+    fn test_ham_addr_to_eui64() {
+        let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
+        let eui64 = addr.to_eui64().unwrap();
+        assert_eq!(eui64.to_hex_string(), "02:48:ed:ff:fe:9c:0c:00");
+        let addr = eui64.to_ham_addr();
+        assert_eq!(addr.to_callsign(), "KZ2X-1");
+        let eui64 = addr.to_eui64().unwrap();
+        assert_eq!(eui64.to_hex_string(), "02:48:ed:ff:fe:9c:0c:00");
+
+        let addr = HamAddr::parse_callsign("AC2OI").unwrap();
+        let eui64 = addr.to_eui64().unwrap();
+        assert_eq!(eui64.to_hex_string(), "02:06:d5:ff:fe:5f:28:00");
+
+        let addr = HamAddr::parse_callsign("WB3KUZ-111").unwrap();
+        let eui64 = addr.to_eui64().unwrap();
+        assert_eq!(eui64.to_hex_string(), "02:90:2e:48:22:f1:fc:af");
+
+        let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
+        let eui64 = addr.to_eui64().unwrap();
+        assert_eq!(eui64.to_hex_string(), "c2:8b:05:0e:89:71:18:a8");
+        let addr = eui64.to_ham_addr();
+        assert_eq!(addr.to_callsign(), "VI2BMARC50");
+        let eui64 = addr.to_eui64().unwrap();
+        assert_eq!(eui64.to_hex_string(), "c2:8b:05:0e:89:71:18:a8");
+    }
+
+    #[test]
+    fn test_ham_addr_to_eui48() {
+        let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
+        let eui48 = addr.to_eui48().unwrap();
+        assert_eq!(eui48.to_hex_string(), "02:48:ed:9c:0c:00");
+
+        let addr = eui48.to_ham_addr();
+        assert_eq!(addr.to_callsign(), "KZ2X-1");
+
+        let addr = HamAddr::parse_callsign("AC2OI").unwrap();
+        let eui48 = addr.to_eui48().unwrap();
+        assert_eq!(eui48.to_hex_string(), "02:06:d5:5f:28:00");
+
+        let addr = HamAddr::parse_callsign("WB3KUZ-1").unwrap();
+        let eui48 = addr.to_eui48().unwrap();
+        assert_eq!(eui48.to_hex_string(), "e2:90:2e:48:22:f1");
+        let addr = eui48.to_ham_addr();
+        assert_eq!(addr.to_callsign(), "WB3KUZ-1");
+
+        let addr = HamAddr::parse_callsign("NA1SS").unwrap();
+        let eui48 = addr.to_eui48().unwrap();
+        assert_eq!(eui48.to_hex_string(), "02:57:c4:79:b8:00");
+        let addr = eui48.to_ham_addr();
+        assert_eq!(addr.to_callsign(), "NA1SS");
+
+        let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
+        let not_eui48 = addr.to_eui48();
+        assert!(matches!(not_eui48, Err(_)));
+    }
+}

--- a/hamaddr/src/lib.rs
+++ b/hamaddr/src/lib.rs
@@ -15,15 +15,17 @@ impl Eui48 {
     }
 }
 /// Converts an Eui48 into a HamAddr
-impl Into<HamAddr> for Eui48 {
-    fn into(self: Self) -> HamAddr {
+impl TryInto<HamAddr> for Eui48 {
+    type Error = anyhow::Error;
+    // TODO(cross): Add error checking.
+    fn try_into(self: Self) -> Result<HamAddr> {
         let mut octets = self.0;
         octets[0] &= 0b1111_1101;
         octets.rotate_left(1);
         let mut bytes = [0; 8];
         bytes[..6].copy_from_slice(&octets);
         let addr = u64::from_be_bytes(bytes);
-        HamAddr(addr)
+        Ok(HamAddr(addr))
     }
 }
 
@@ -63,8 +65,10 @@ impl fmt::Display for Eui64 {
 }
 
 /// Converts an Eui64 into a HamAddr.
-impl Into<HamAddr> for Eui64 {
-    fn into(self: Self) -> HamAddr {
+impl TryInto<HamAddr> for Eui64 {
+    type Error = anyhow::Error;
+    // TODO(cross): Add error checking.
+    fn try_into(self: Self) -> Result<HamAddr> {
         let mut bytes = self.0;
         bytes[0] &= 0b1111_1101;
         if bytes[3] == 0xFF && bytes[4] == 0xFE {
@@ -76,7 +80,7 @@ impl Into<HamAddr> for Eui64 {
             bytes.rotate_left(1);
         }
         let addr = u64::from_be_bytes(bytes);
-        HamAddr(addr)
+        Ok(HamAddr(addr))
     }
 }
 
@@ -284,7 +288,7 @@ mod ham_addr_tests {
         let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
         let eui64: Eui64 = addr.try_into().unwrap();
         assert_eq!(eui64.to_string(), "02:48:ed:ff:fe:9c:0c:00");
-        let addr: HamAddr = eui64.into();
+        let addr: HamAddr = eui64.try_into().unwrap();
         assert_eq!(addr.to_callsign(), "KZ2X-1");
         let eui64: Eui64 = addr.try_into().unwrap();
         assert_eq!(eui64.to_string(), "02:48:ed:ff:fe:9c:0c:00");
@@ -300,7 +304,7 @@ mod ham_addr_tests {
         let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
         let eui64: Eui64 = addr.try_into().unwrap();
         assert_eq!(eui64.to_string(), "c2:8b:05:0e:89:71:18:a8");
-        let addr: HamAddr = eui64.into();
+        let addr: HamAddr = eui64.try_into().unwrap();
         assert_eq!(addr.to_callsign(), "VI2BMARC50");
         let eui64: Eui64 = addr.try_into().unwrap();
         assert_eq!(eui64.to_string(), "c2:8b:05:0e:89:71:18:a8");
@@ -312,7 +316,7 @@ mod ham_addr_tests {
         let eui48: Eui48 = addr.try_into().unwrap();
         assert_eq!(eui48.to_string(), "02:48:ed:9c:0c:00");
 
-        let addr: HamAddr = eui48.into();
+        let addr: HamAddr = eui48.try_into().unwrap();
         assert_eq!(addr.to_callsign(), "KZ2X-1");
 
         let addr = HamAddr::parse_callsign("AC2OI").unwrap();
@@ -322,13 +326,13 @@ mod ham_addr_tests {
         let addr = HamAddr::parse_callsign("WB3KUZ-1").unwrap();
         let eui48: Eui48 = addr.try_into().unwrap();
         assert_eq!(eui48.to_string(), "e2:90:2e:48:22:f1");
-        let addr: HamAddr = eui48.into();
+        let addr: HamAddr = eui48.try_into().unwrap();
         assert_eq!(addr.to_callsign(), "WB3KUZ-1");
 
         let addr = HamAddr::parse_callsign("NA1SS").unwrap();
         let eui48: Eui48 = addr.try_into().unwrap();
         assert_eq!(eui48.to_string(), "02:57:c4:79:b8:00");
-        let addr: HamAddr = eui48.into();
+        let addr: HamAddr = eui48.try_into().unwrap();
         assert_eq!(addr.to_callsign(), "NA1SS");
 
         let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();

--- a/hamaddr/src/lib.rs
+++ b/hamaddr/src/lib.rs
@@ -1,25 +1,22 @@
-type Result<T> = std::result::Result<T, String>;
+use std::convert::TryInto;
+use std::fmt;
+use anyhow::{bail, format_err};
+
+type Result<T> = std::result::Result<T, anyhow::Error>;
 
 /// Eui48 represents an EUI48 MAC address.
-pub struct Eui48([u8; 6]);
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Eui48(pub [u8; 6]);
 
 impl Eui48 {
     /// Creates a new Eui48 from the given six octets.
     pub const fn new(addr: [u8; 6]) -> Eui48 {
         Eui48(addr)
     }
-
-    /// Returns a string representing the Eui48.
-    pub fn to_hex_string(&self) -> String {
-        let bs = &self.0;
-        format!(
-            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-            bs[0], bs[1], bs[2], bs[3], bs[4], bs[5]
-        )
-    }
-
-    /// Returns a HamAddr from the Eui48.
-    pub fn to_ham_addr(&self) -> HamAddr {
+}
+/// Converts an Eui48 into a HamAddr
+impl Into<HamAddr> for Eui48 {
+    fn into(self: Self) -> HamAddr {
         let mut octets = self.0;
         octets[0] &= 0b1111_1101;
         octets.rotate_left(1);
@@ -30,26 +27,44 @@ impl Eui48 {
     }
 }
 
+/// Formats an Eui48 for display.
+impl fmt::Display for Eui48 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bs = &self.0;
+        write!(
+            f,
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            bs[0], bs[1], bs[2], bs[3], bs[4], bs[5]
+        )
+    }
+}
+
 /// Eui64 represents an EUI64 MAC address.
-pub struct Eui64([u8; 8]);
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Eui64(pub [u8; 8]);
 
 impl Eui64 {
     /// Creates a new Eui64 from the given 8 octets.
     pub const fn new(addr: [u8; 8]) -> Eui64 {
         Eui64(addr)
     }
+}
 
-    /// Returns a string representing the Eui64.
-    pub fn to_hex_string(&self) -> String {
+/// Formats an Eui64 for display.
+impl fmt::Display for Eui64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let bs = &self.0;
-        format!(
+        write!(
+            f,
             "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
             bs[0], bs[1], bs[2], bs[3], bs[4], bs[5], bs[6], bs[7]
         )
     }
+}
 
-    /// Returns a HamAddr from the Eui64.
-    pub fn to_ham_addr(&self) -> HamAddr {
+/// Converts an Eui64 into a HamAddr.
+impl Into<HamAddr> for Eui64 {
+    fn into(self: Self) -> HamAddr {
         let mut bytes = self.0;
         bytes[0] &= 0b1111_1101;
         if bytes[3] == 0xFF && bytes[4] == 0xFE {
@@ -89,21 +104,22 @@ mod eui_tests {
     }
 
     #[test]
-    fn test_to_hex_str_eui48() {
+    fn test_to_str_eui48() {
         let eui = Eui48::new([1, 2, 3, 4, 5, 6]);
-        let s = eui.to_hex_string();
+        let s = eui.to_string();
         assert_eq!(s, "01:02:03:04:05:06");
     }
 
     #[test]
-    fn test_to_hex_str_eui64() {
+    fn test_to_str_eui64() {
         let eui = Eui64::new([1, 2, 3, 4, 5, 6, 0x77, 0x88]);
-        let s = eui.to_hex_string();
+        let s = eui.to_string();
         assert_eq!(s, "01:02:03:04:05:06:77:88");
     }
 }
 
 /// An ARNCE encoded address
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct HamAddr(u64);
 
 impl HamAddr {
@@ -114,7 +130,7 @@ impl HamAddr {
         fn char_to_index(c: char) -> Result<u16> {
             HamAddr::CHARS
                 .find(c)
-                .ok_or(format!("bad char '{}'", c))
+                .ok_or(format_err!("bad char '{}'", c))
                 .map(|k| k as u16 + 1)
         }
         fn chunk_to_u16(chunk: &[char]) -> u16 {
@@ -128,11 +144,11 @@ impl HamAddr {
         }
         for c in callsign.to_uppercase().chars() {
             if !HamAddr::CHARS.contains(c) {
-                return Err(format!("Callsign contains bad character '{}'", c));
+                bail!("Callsign contains bad character '{}'", c);
             }
         }
         if callsign.len() > 12 {
-            return Err(format!("Callsign '{}' is too long", callsign));
+            bail!("Callsign '{}' is too long", callsign);
         }
         let numeric = callsign
             .to_uppercase()
@@ -172,39 +188,17 @@ impl HamAddr {
             .join("")
     }
 
-    /// Returns a hex string representing the HamAddr.
-    pub fn to_hex_string(&self) -> String {
-        let cs = [
-            (self.0 >> 48) as u16,
-            (self.0 >> 32) as u16,
-            (self.0 >> 16) as u16,
-            self.0 as u16,
-        ];
-        cs.iter()
-            .filter(|c| **c != 0)
-            .map(|c| format!("{:04X}", *c))
-            .collect::<Vec<_>>()
-            .join(":")
-    }
-
     /// Returns a HAM64 encoded string corresponding to the HamAddr.
     pub fn to_ham64_string(&self) -> String {
-        let cs = [
-            (self.0 >> 48) as u16,
-            (self.0 >> 32) as u16,
-            (self.0 >> 16) as u16,
-            self.0 as u16,
-        ];
-        cs.iter()
-            .map(|c| format!("{:04X}", *c))
-            .collect::<Vec<_>>()
-            .join("-")
+        format!("{:#}", self)
     }
+}
 
-    /// Attempts to convert the HamAddr to an Eui64.
-    pub fn to_eui64(&self) -> Result<Eui64> {
+impl TryInto<Eui64> for HamAddr {
+    type Error = anyhow::Error;
+    fn try_into(self: Self) -> Result<Eui64> {
         if self.0 & 0b0111 != 0 {
-            return Err("HamAddr too big".to_string());
+            bail!("HamAddr too big");
         }
         let is_small = self.0 & 0x0000_0000_0007_FFFF == 0;
         let mut bytes = self.0.to_be_bytes();
@@ -218,17 +212,39 @@ impl HamAddr {
         }
         Ok(Eui64::new(bytes))
     }
+}
 
-    /// Attempts to convert the HamAddr to an Eui48.
-    pub fn to_eui48(&self) -> Result<Eui48> {
+impl TryInto<Eui48> for HamAddr {
+    type Error = anyhow::Error;
+    fn try_into(self: Self) -> Result<Eui48> {
         if self.0 & 0x0000_0000_0007_FFFF != 0 {
-            return Err("HamAddr too big".to_string());
+            bail!("HamAddr too big");
         }
         let mut bytes = [0, 0, 0, 0, 0, 0];
         bytes.copy_from_slice(&self.0.to_be_bytes()[..6]);
         bytes.rotate_right(1);
         bytes[0] = (bytes[0] & 0b1111_1000) | 0b0010;
         Ok(Eui48::new(bytes))
+    }
+}
+
+impl fmt::Display for HamAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            [
+                (self.0 >> 48) as u16,
+                (self.0 >> 32) as u16,
+                (self.0 >> 16) as u16,
+                self.0 as u16,
+            ]
+            .iter()
+            .filter(|c| f.alternate() || **c != 0)
+            .map(|c| format!("{:04X}", *c))
+            .collect::<Vec<_>>()
+            .join(if f.alternate() { "-" } else { ":" })
+        )
     }
 }
 
@@ -245,14 +261,14 @@ mod ham_addr_tests {
     #[test]
     fn test_ham_addr_to_hex_string() {
         let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
-        assert_eq!(addr.to_hex_string(), "48ED:9C0C");
+        assert_eq!(addr.to_string(), "48ED:9C0C");
 
         let addr = HamAddr::parse_callsign("N6DRC").unwrap();
-        assert_eq!(addr.to_hex_string(), "5CAC:70F8");
+        assert_eq!(addr.to_string(), "5CAC:70F8");
         assert_eq!(addr.to_ham64_string(), "5CAC-70F8-0000-0000");
 
         let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
-        assert_eq!(addr.to_hex_string(), "8B05:0E89:7118:A8C0");
+        assert_eq!(addr.to_string(), "8B05:0E89:7118:A8C0");
 
         // TODO(cross): This was one of the test vectors from the
         // ARNCE specification, but the encoded ham64 string does
@@ -266,57 +282,57 @@ mod ham_addr_tests {
     #[test]
     fn test_ham_addr_to_eui64() {
         let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
-        let eui64 = addr.to_eui64().unwrap();
-        assert_eq!(eui64.to_hex_string(), "02:48:ed:ff:fe:9c:0c:00");
-        let addr = eui64.to_ham_addr();
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "02:48:ed:ff:fe:9c:0c:00");
+        let addr: HamAddr = eui64.into();
         assert_eq!(addr.to_callsign(), "KZ2X-1");
-        let eui64 = addr.to_eui64().unwrap();
-        assert_eq!(eui64.to_hex_string(), "02:48:ed:ff:fe:9c:0c:00");
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "02:48:ed:ff:fe:9c:0c:00");
 
         let addr = HamAddr::parse_callsign("AC2OI").unwrap();
-        let eui64 = addr.to_eui64().unwrap();
-        assert_eq!(eui64.to_hex_string(), "02:06:d5:ff:fe:5f:28:00");
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "02:06:d5:ff:fe:5f:28:00");
 
         let addr = HamAddr::parse_callsign("WB3KUZ-111").unwrap();
-        let eui64 = addr.to_eui64().unwrap();
-        assert_eq!(eui64.to_hex_string(), "02:90:2e:48:22:f1:fc:af");
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "02:90:2e:48:22:f1:fc:af");
 
         let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
-        let eui64 = addr.to_eui64().unwrap();
-        assert_eq!(eui64.to_hex_string(), "c2:8b:05:0e:89:71:18:a8");
-        let addr = eui64.to_ham_addr();
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "c2:8b:05:0e:89:71:18:a8");
+        let addr: HamAddr = eui64.into();
         assert_eq!(addr.to_callsign(), "VI2BMARC50");
-        let eui64 = addr.to_eui64().unwrap();
-        assert_eq!(eui64.to_hex_string(), "c2:8b:05:0e:89:71:18:a8");
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "c2:8b:05:0e:89:71:18:a8");
     }
 
     #[test]
     fn test_ham_addr_to_eui48() {
         let addr = HamAddr::parse_callsign("KZ2X-1").unwrap();
-        let eui48 = addr.to_eui48().unwrap();
-        assert_eq!(eui48.to_hex_string(), "02:48:ed:9c:0c:00");
+        let eui48: Eui48 = addr.try_into().unwrap();
+        assert_eq!(eui48.to_string(), "02:48:ed:9c:0c:00");
 
-        let addr = eui48.to_ham_addr();
+        let addr: HamAddr = eui48.into();
         assert_eq!(addr.to_callsign(), "KZ2X-1");
 
         let addr = HamAddr::parse_callsign("AC2OI").unwrap();
-        let eui48 = addr.to_eui48().unwrap();
-        assert_eq!(eui48.to_hex_string(), "02:06:d5:5f:28:00");
+        let eui48: Eui48 = addr.try_into().unwrap();
+        assert_eq!(eui48.to_string(), "02:06:d5:5f:28:00");
 
         let addr = HamAddr::parse_callsign("WB3KUZ-1").unwrap();
-        let eui48 = addr.to_eui48().unwrap();
-        assert_eq!(eui48.to_hex_string(), "e2:90:2e:48:22:f1");
-        let addr = eui48.to_ham_addr();
+        let eui48: Eui48 = addr.try_into().unwrap();
+        assert_eq!(eui48.to_string(), "e2:90:2e:48:22:f1");
+        let addr: HamAddr = eui48.into();
         assert_eq!(addr.to_callsign(), "WB3KUZ-1");
 
         let addr = HamAddr::parse_callsign("NA1SS").unwrap();
-        let eui48 = addr.to_eui48().unwrap();
-        assert_eq!(eui48.to_hex_string(), "02:57:c4:79:b8:00");
-        let addr = eui48.to_ham_addr();
+        let eui48: Eui48 = addr.try_into().unwrap();
+        assert_eq!(eui48.to_string(), "02:57:c4:79:b8:00");
+        let addr: HamAddr = eui48.into();
         assert_eq!(addr.to_callsign(), "NA1SS");
 
         let addr = HamAddr::parse_callsign("VI2BMARC50").unwrap();
-        let not_eui48 = addr.to_eui48();
+        let not_eui48: Result<Eui48> = addr.try_into();
         assert!(matches!(not_eui48, Err(_)));
     }
 }

--- a/hamaddr/src/lib.rs
+++ b/hamaddr/src/lib.rs
@@ -1,6 +1,6 @@
+use anyhow::{bail, format_err};
 use std::convert::TryInto;
 use std::fmt;
-use anyhow::{bail, format_err};
 
 type Result<T> = std::result::Result<T, anyhow::Error>;
 

--- a/sh/callsign-to-eui48
+++ b/sh/callsign-to-eui48
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # 2015-10-30
 #

--- a/sh/callsign-to-eui64
+++ b/sh/callsign-to-eui64
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # 2015-10-30
 #

--- a/sh/callsign-to-ham-addr
+++ b/sh/callsign-to-ham-addr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # 2015-10-30
 #

--- a/sh/ham-addr-to-callsign
+++ b/sh/ham-addr-to-callsign
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # 2015-10-30
 #

--- a/sh/mac-to-callsign
+++ b/sh/mac-to-callsign
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # 2015-10-30
 #


### PR DESCRIPTION
This might still be considered WIP, but I'd like at least initial comments, time permitting.

What's there:
* Basic code for parsing callsign into a HamAddr
* Converting a HamAddr back to a callsign
* Rudimentary Eui48/Eui64 types and code to convert an Eui48 to an Eui64
* Eui48/Eui64 to and from HamAddr

What's missing:
* Additional methods on the EUI types for detecting multicast addresses, etc.
* A TryFrom method to convert an Eui64 to an Eui48.
* Error checking can and should be improved.